### PR TITLE
Add a default delay of 200ms

### DIFF
--- a/terminal.js
+++ b/terminal.js
@@ -89,6 +89,6 @@ function runTerminalLineType($line, $terminal, $target, index) {
 
   $nextLine = $line.next('[data-terminal]');
   if( $nextLine.length ) {
-    runTerminalLine($nextLine, $terminal, message.length*$defaultDelay);
+    runTerminalLine($nextLine, $terminal, $defaultDelay);
   }
 }

--- a/terminal.js
+++ b/terminal.js
@@ -22,26 +22,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
+
+$defaultDelay = 200;
+
 function runTerminal($terminal) {
   if( ! $terminal.data('terminalPrompt').length ) {
     $terminal.data('terminalPrompt','$ ');
   }
 
-  runTerminalLine($terminal.find('[data-terminal]:first'), $terminal);
+  runTerminalLine($terminal.find('[data-terminal]:first'), $terminal, $defaultDelay);
 }
 
-function runTerminalLine($line, $terminal) {
+function runTerminalLine($line, $terminal, $delay) {
+  if( $line.is("[data-terminal-time]") ) {
+    $delay = parseInt($line.data('terminalTime'));
+  }
   if( $line.data('terminalMessage') == "prompt" ) {
     $line.data('terminalMessage', $terminal.data('terminalPrompt'));
   }
   if( $line.data('terminal') == "line" ) {
     setTimeout(function () {
       runTerminalLinePrint($line, $terminal);
-    }, parseInt($line.data('terminalTime')) );
+    }, $delay )
   } else {
     setTimeout(function () {
       runTerminalLineType($line, $terminal);
-    }, parseInt($line.data('terminalTime')) );
+    }, $delay )
   }
 }
 
@@ -50,12 +56,12 @@ function runTerminalLinePrint($line, $terminal) {
   var $output = $terminal.find('.output');
   $output.append($target);
   $target.append($line.data('terminalMessage'));
-  
+
   $output.animate({ scrollTop: $output[0].scrollHeight}, 1);
 
   $nextLine = $line.next('[data-terminal]');
   if( $nextLine.length ) {
-    runTerminalLine($nextLine, $terminal);
+    runTerminalLine($nextLine, $terminal, $defaultDelay);
   }
 }
 
@@ -83,6 +89,6 @@ function runTerminalLineType($line, $terminal, $target, index) {
 
   $nextLine = $line.next('[data-terminal]');
   if( $nextLine.length ) {
-    runTerminalLine($nextLine, $terminal);
+    runTerminalLine($nextLine, $terminal, message.length*$defaultDelay);
   }
 }


### PR DESCRIPTION
Removes the need to specify a `data-terminal-time` attribute every time, defaults to 200ms instead.
